### PR TITLE
Prevent loading skip menu twice

### DIFF
--- a/src/SkipMenuComponents/Menu.tsx
+++ b/src/SkipMenuComponents/Menu.tsx
@@ -1,24 +1,64 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useRef, useEffect, useState } from 'react';
 import { SkipMenu, SkipMenuConfig } from './js/skipMenu';
+
+// Because React 18 in strict mode will call useEffect twice, this function will
+// ensure that the code is only run once.
+// This prevents the skip menu from being loaded twice.
+
+const useEffectOnce = (effect: () => void | (() => void)) => {
+  const destroyFunc = useRef<void | (() => void)>();
+  const effectCalled = useRef(false);
+  const renderAfterCalled = useRef(false);
+  const [val, setVal] = useState<number>(0);
+
+  if (effectCalled.current) {
+    renderAfterCalled.current = true;
+  }
+
+  useEffect(() => {
+    // only execute the effect first time around
+    if (!effectCalled.current) {
+      destroyFunc.current = effect();
+      effectCalled.current = true;
+    }
+
+    // this forces one render after the effect is run
+    setVal(val + 1);
+
+    return () => {
+      // if the comp didn't render since the useEffect was called,
+      // we know it's the dummy React cycle
+      if (!renderAfterCalled.current) {
+        return;
+      }
+      if (destroyFunc.current) {
+        destroyFunc.current();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
 
 const Menu = (props: SkipMenuConfig): ReactElement => {
   const menuRef = React.useRef(null);
 
   const [skipMenu, setSkipMenu] = React.useState<SkipMenu | null>(null);
 
-  React.useEffect(() => {
-    const skipMenuProps: SkipMenuConfig = {
-      attachTo: menuRef.current,
-      reloadOnChange: true,
-    };
-    Object.keys(props).map((key) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      skipMenuProps[key] = props[key];
-    });
-    const newSkipMenu = new SkipMenu(skipMenuProps);
-    newSkipMenu.init();
-    setSkipMenu(newSkipMenu);
+  useEffectOnce(() => {
+    if (!skipMenu) {
+      const skipMenuProps: SkipMenuConfig = {
+        attachTo: menuRef.current,
+        reloadOnChange: true,
+      };
+      Object.keys(props).map((key) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        skipMenuProps[key] = props[key];
+      });
+      const newSkipMenu = new SkipMenu(skipMenuProps);
+      newSkipMenu.init();
+      setSkipMenu(newSkipMenu);
+    }
 
     return function cleanup() {
       if (skipMenu !== null) {
@@ -26,7 +66,7 @@ const Menu = (props: SkipMenuConfig): ReactElement => {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 
   // *** Return ***
   return <div data-testid='componentContent' ref={menuRef} />;

--- a/src/SkipMenuComponents/js/skipMenu.ts
+++ b/src/SkipMenuComponents/js/skipMenu.ts
@@ -33,7 +33,7 @@ export class SkipMenu {
     this.getConfig = this.getConfig.bind(this);
   }
 
-  static version = 'v1.3.1'; // Note - this is replaced on build
+  static version = 'v1.3.2'; // Note - this is replaced on build
 
   getConfig() {
     return this.config;

--- a/src/SkipMenuComponents/scss/_skipMenu-base.scss
+++ b/src/SkipMenuComponents/scss/_skipMenu-base.scss
@@ -3,7 +3,7 @@
   position: absolute;
   left: 50%;
   transform: translate(-50%);
-  z-index: 999;
+  z-index: 9999;
   top: 0;
 
   &.skipMenu-hidden {
@@ -18,6 +18,7 @@
       left: 1.5rem;
     }
 
+    position: absolute;
     opacity: 1;
     display: none;
   }


### PR DESCRIPTION
**Description:**

Because React 18 in strict mode will call useEffect twice, this function will ensure that the code is only run once. This prevents the skip menu from being loaded twice.

Also pulls changes from SkipMenu 1.3.2


**Expected Version Change:**

patch
